### PR TITLE
feat: 사용자 CRUD

### DIFF
--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/controller/UserController.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/controller/UserController.java
@@ -1,0 +1,95 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.controller;
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.DeleteUserResponseDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserInfoRequestDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserNicknameUpdateDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserResponseDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.service.UserService;
+
+@RestController
+@RequestMapping("/api/user")
+public class UserController {
+	Logger log = LoggerFactory.getLogger(UserController.class);
+
+	private final UserService userService;
+
+	public UserController(UserService userService) {
+		this.userService = userService;
+	}
+
+	/**
+	 * 📍 소셜 로그인 후 회원 정보 등록
+	 * @param userInfoRequestDto 회원 정보 등록 DTO
+	 * @return 등록된 회원 정보
+	 */
+	@PostMapping("/create")
+	public ResponseEntity<UserResponseDto> createUser(@RequestBody UserInfoRequestDto userInfoRequestDto) {
+		log.info("Create user request: {}", userInfoRequestDto);
+		UserResponseDto userResponseDto = userService.createUser(userInfoRequestDto);
+		return new ResponseEntity<>(userResponseDto, HttpStatus.CREATED);
+	}
+
+	/**
+	 * 📍 회원 전체 조회
+	 * @return 모든 회원 리스트
+	 */
+	@GetMapping
+	public ResponseEntity<List<UserResponseDto>> getAllUsers() {
+		log.info("Get all users");
+		List<UserResponseDto> users = userService.getAllUsers();
+		return new ResponseEntity<>(users, HttpStatus.OK);
+	}
+
+	/**
+	 * 📍 회원 단일 조회
+	 * @param id 회원 id
+	 * @return 회원 정보
+	 */
+	@GetMapping("/{id}")
+	public ResponseEntity<UserResponseDto> getUserById(@PathVariable("id") Long id) {
+		log.info("Get user by id: {}", id);
+		UserResponseDto user = userService.getUserById(id);
+		return new ResponseEntity<>(user, HttpStatus.OK);
+	}
+
+	/**
+	 * 📍 회원 닉네임 수정
+	 * @param id 회원 id
+	 * @param userNicknameUpdateDto 수정할 닉네임
+	 * @return 수정된 회원 닉네임 정보 (id, 수정된 닉네임, 수정 시각)
+	 */
+	@PatchMapping("/{id}/nickname")
+	public ResponseEntity<UserResponseDto> updateUserNickname(@PathVariable("id") Long id,
+		@RequestBody UserNicknameUpdateDto userNicknameUpdateDto) {
+		log.info("Update user nickname: {}", userNicknameUpdateDto.getNickname());
+		UserResponseDto user = userService.updateUserNickname(id, userNicknameUpdateDto);
+		return new ResponseEntity<>(user, HttpStatus.OK);
+	}
+
+	/**
+	 * 📍 회원 삭제
+	 * 상태 INACTIVE로 변경
+	 * @param id 회원 id
+	 * @return 삭제된 회원 정보 (id, 닉네임, 상태(INACTIVE), 삭제일자)
+	 */
+	@PatchMapping("/{id}/status")
+	public ResponseEntity<DeleteUserResponseDto> deleteUser(@PathVariable("id") Long id) {
+		log.info("Delete user: {}", id);
+		DeleteUserResponseDto user = userService.deleteUser(id);
+		return new ResponseEntity<>(user, HttpStatus.OK);
+	}
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/controller/UserExceptionHandler.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/controller/UserExceptionHandler.java
@@ -1,0 +1,33 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.controller;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RestControllerAdvice
+public class UserExceptionHandler {
+    
+    private static final Logger log = LoggerFactory.getLogger(UserExceptionHandler.class);
+    
+    /**
+     * IllegalArgumentException 처리
+     * 이미 INACTIVE인 회원에게 상태 변경 요청 시 400 Bad Request 반환
+     */
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<Map<String, Object>> handleIllegalArgumentException(IllegalArgumentException e) {
+        log.warn("IllegalArgumentException occurred: {}", e.getMessage());
+        
+        Map<String, Object> response = new HashMap<>();
+        response.put("error", "Bad Request");
+        response.put("message", e.getMessage());
+        response.put("status", HttpStatus.BAD_REQUEST.value());
+        
+        return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+    }
+} 

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/DeleteUserResponseDto.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/DeleteUserResponseDto.java
@@ -1,0 +1,23 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.dto;
+
+import java.time.LocalDateTime;
+
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Status;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class DeleteUserResponseDto {
+	private Long id;
+	private String nickname;
+	private Status status;
+	private LocalDateTime deletedAt;
+} 

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserInfoRequestDto.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserInfoRequestDto.java
@@ -1,0 +1,22 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.dto;
+
+import java.time.LocalDate;
+
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Gender;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class UserInfoRequestDto {
+	private String nickname;
+	private Gender gender;
+	private LocalDate birth;
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserNicknameUpdateDto.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserNicknameUpdateDto.java
@@ -1,0 +1,16 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class UserNicknameUpdateDto {
+	private String nickname;
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserResponseDto.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserResponseDto.java
@@ -1,0 +1,26 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.dto;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Gender;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@ToString
+public class UserResponseDto {
+	private Long id;
+	private String nickname;
+	private Gender gender;
+	private LocalDate birth;
+	private String email;
+	private LocalDateTime createdAt;
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserResponseDto.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/dto/UserResponseDto.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 
 import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Gender;
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Status;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -22,5 +23,6 @@ public class UserResponseDto {
 	private Gender gender;
 	private LocalDate birth;
 	private String email;
+	private Status status;
 	private LocalDateTime createdAt;
 }

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/entity/Role.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/entity/Role.java
@@ -1,0 +1,5 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.entity;
+
+public enum Role {
+	USER, ADMIN
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/entity/User.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/model/entity/User.java
@@ -1,0 +1,71 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.model.entity;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Gender;
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Status;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import lombok.ToString;
+
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+@Setter
+@ToString // 콘솔 테스트용
+@Entity
+@Table(name = "users")
+public class User {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "id")
+	private Long id;
+
+	@Column(name = "nickname", nullable = false)
+	private String nickname;
+
+	@Column(name = "gender", nullable = false)
+	private Gender gender;
+
+	@Column(name = "birth", nullable = false)
+	private LocalDate birth;
+
+	@Column(name = "email", nullable = false)
+	private String email;
+
+	@Builder.Default
+	@Column(name = "role", nullable = false)
+	private Role role = Role.USER;
+
+	@Column(name = "status", nullable = false)
+	private Status status;
+
+	@Builder.Default
+	@Column(name = "created_at", nullable = false)
+	private LocalDateTime createdAt = LocalDateTime.now();
+
+	@Column(name = "updated_at")
+	private LocalDateTime updatedAt;
+
+	@Column(name = "deleted_at")
+	private LocalDateTime deletedAt;
+
+	@PrePersist
+	public void prePersist() {
+		this.createdAt = (this.createdAt == null) ? LocalDateTime.now() : this.createdAt;
+	}
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/repository/UserRepository.java
@@ -1,0 +1,10 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import com.ohgiraffers.togedaeng.backend.domain.user.model.entity.User;
+
+@Repository
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/service/UserService.java
+++ b/src/main/java/com/ohgiraffers/togedaeng/backend/domain/user/service/UserService.java
@@ -1,0 +1,170 @@
+package com.ohgiraffers.togedaeng.backend.domain.user.service;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import com.ohgiraffers.togedaeng.backend.domain.dog.entity.Status;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.DeleteUserResponseDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserInfoRequestDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserNicknameUpdateDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.dto.UserResponseDto;
+import com.ohgiraffers.togedaeng.backend.domain.user.model.entity.User;
+import com.ohgiraffers.togedaeng.backend.domain.user.repository.UserRepository;
+
+@Service
+public class UserService {
+
+	Logger log = LoggerFactory.getLogger(UserService.class);
+
+	private final UserRepository userRepository;
+
+	public UserService(UserRepository userRepository) {
+		this.userRepository = userRepository;
+	}
+
+	/**
+	 * 📍 소셜 로그인 후 회원 정보 등록
+	 * @param dto 회원 정보 등록 DTO
+	 * @return 등록된 회원 DTO 변환
+	 */
+	public UserResponseDto createUser(UserInfoRequestDto dto) {
+		try {
+			User user = User.builder()
+				.nickname(dto.getNickname())
+				.gender(dto.getGender())
+				.birth(dto.getBirth())
+				.email("temp@email.com") // TODO: 소셜 로그인에서 받아온 이메일로 수정
+				.status(Status.ACTIVE)
+				.createdAt(LocalDateTime.now())
+				.build();
+
+			User savedUser = userRepository.save(user);
+			log.info("Creating new user: {}", dto.getNickname());
+
+			return new UserResponseDto(
+				savedUser.getId(),
+				savedUser.getNickname(),
+				savedUser.getGender(),
+				savedUser.getBirth(),
+				savedUser.getEmail(),
+				savedUser.getCreatedAt()
+			);
+		} catch (Exception e) {
+			e.printStackTrace();
+			return null;
+		}
+	}
+
+	/**
+	 * 📍 회원 전체 조회
+	 * @return 모든 회원 리스트
+	 */
+	public List<UserResponseDto> getAllUsers() {
+		List<User> users = userRepository.findAll();
+		List<UserResponseDto> userResponseDtos = new ArrayList<>();
+
+		for (User user : users) {
+			userResponseDtos.add(new UserResponseDto(
+				user.getId(),
+				user.getNickname(),
+				user.getGender(),
+				user.getBirth(),
+				user.getEmail(),
+				user.getCreatedAt()
+			));
+		}
+
+		log.info("Get all users: {}", userResponseDtos);
+
+		return userResponseDtos;
+	}
+
+	/**
+	 * 📍 회원 단일 조회
+	 * @param id 회원 id
+	 * @return 회원 정보 DTO 변환
+	 */
+	public UserResponseDto getUserById(Long id) {
+		User user = userRepository.findById(id).orElse(null);
+		log.info("Get user by id: {}", id);
+
+		if (user == null) {
+			return null;
+		}
+
+		return new UserResponseDto(
+			user.getId(),
+			user.getNickname(),
+			user.getGender(),
+			user.getBirth(),
+			user.getEmail(),
+			user.getCreatedAt()
+		);
+	}
+
+	/**
+	 * 📍 회원 닉네임 수정
+	 * @param id 회원 id
+	 * @param dto 수정할 닉네임
+	 * @return 수정된 회원 정보
+	 */
+	public UserResponseDto updateUserNickname(Long id, UserNicknameUpdateDto dto) {
+		User user = userRepository.findById(id).orElseThrow(() ->
+			new IllegalArgumentException("User not found"));
+
+		log.info("Update user nickname: {}", dto.getNickname());
+
+		user.setNickname(dto.getNickname());
+		user.setUpdatedAt(LocalDateTime.now());
+
+		User updatedUser = userRepository.save(user);
+
+		return new UserResponseDto(
+			updatedUser.getId(),
+			updatedUser.getNickname(),
+			updatedUser.getGender(),
+			updatedUser.getBirth(),
+			updatedUser.getEmail(),
+			updatedUser.getCreatedAt()
+		);
+	}
+
+	/**
+	 * 📍 회원 삭제
+	 * @param id 회원 id
+	 * @return 삭제된 회원 정보 (id, 닉네임, 상태(INACTIVE), 삭제일자)
+	 */
+	public DeleteUserResponseDto deleteUser(Long id) {
+		// 유효성 검증: ID가 유효한지 확인
+		if (id == null) {
+			throw new IllegalArgumentException("User ID cannot be null");
+		}
+
+		User user = userRepository.findById(id).orElseThrow(() ->
+			new IllegalArgumentException("User not found"));
+
+		// 유효성 검증: 이미 INACTIVE 상태인지 확인
+		if (user.getStatus() == Status.INACTIVE) {
+			throw new IllegalArgumentException("User is already inactive");
+		}
+
+		log.info("Delete user: {}", id);
+
+		user.setStatus(Status.INACTIVE);
+		user.setDeletedAt(LocalDateTime.now());
+
+		User updatedUser = userRepository.save(user);
+
+		return new DeleteUserResponseDto(
+			updatedUser.getId(),
+			updatedUser.getNickname(),
+			updatedUser.getStatus(),
+			updatedUser.getDeletedAt()
+		);
+	}
+}


### PR DESCRIPTION
### 📌 작업 개요
사용자 도메인에 대한 CRUD API 설계 및 구현

---

### 🔍 주요 개발/변경 사항
- 사용자 등록, 닉네임 수정, 전체조회, 단일조회, 삭제(탈퇴, SOFT) 구현
- 탈퇴, 차단된 사용자가 같은 기능 재 시도 시, 익셉션 핸들러로 제어

---

### ✅ 체크리스트
- [v] 로컬 테스트 완료  
- [v] 이슈와 연관된 기능 구현  
- [v] 팀 코드 스타일 준수

---

### 📝 기타 사항
- Postman을 통해 등록/조회/삭제 정상 작동 확인 완료
- DB 데이터 정상 반영 및 예외 없이 작동 확인
